### PR TITLE
Fixes #24 - Don't encrypt empty strings with SecureField

### DIFF
--- a/cincoconfig/fields.py
+++ b/cincoconfig/fields.py
@@ -1071,8 +1071,8 @@ class SecureField(Field):
         super().__init__(**kwargs)
         self.method = method
 
-    def to_basic(self, cfg: BaseConfig, value: str) -> dict:
-        if value is None:
+    def to_basic(self, cfg: BaseConfig, value: str) -> Optional[dict]:
+        if not value:
             return None
 
         with cfg._keyfile as ctx:

--- a/tests/test_fields/test_secure.py
+++ b/tests/test_fields/test_secure.py
@@ -33,6 +33,10 @@ class TestSecureField:
         field = SecureField()
         assert field.to_basic(None, None) is None
 
+    def test_to_basic_empty_string(self):
+        field = SecureField()
+        assert field.to_basic(None, "") is None
+
     def test_to_basic(self):
         cfg = StubConfig()
         field = SecureField(method='test')
@@ -47,6 +51,10 @@ class TestSecureField:
     def test_to_python_none(self):
         field = SecureField()
         assert field.to_python(None, None) is None
+
+    def test_to_python_empty_string(self):
+        field = SecureField()
+        assert field.to_python(None, "") == ""
 
     def test_to_python_str(self):
         field = SecureField()


### PR DESCRIPTION
Now returns `None` if the string is empty for `SecureField`. Changed the return type-hint to `Optional[dict]` to satisfy linting. Added tests for empty string to `to_basic` and `to_python`. `to_python` functionality remains the same and returns an empty string if it receives an empty string which I believe is appropriate.