### PR TITLE
Multiple Improvements and Fixes (again)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v0.6.0] - 2020-11-05
 ### Added
-- `Config.to_tree()` now supports masking secure values (`secure_mask` parameter) and including
-  virtual fields in the tree (`virtual` parameter).
+- `Field.sensitive` property to mark a value as sensitive.
+- `Config.to_tree()` now supports masking sensitive values (`sensitive_mask` parameter) and
+  including virtual fields in the tree (`virtual` parameter).
+
+### Changed
+- `StringField` now only accepts string values. Prior to this release, all input values were
+  coerced to a string, via `str(value)`. This was causing inconsistencies and non-intuitive
+  behavior for fields that inherited from `StringField`.
+- Refactor `ListProxy` to inherit from `list`.
+
+### Fixed
+- `ListField` now handles empty or `None` values.
 
 ## [v0.5.0] - 2020-10-31
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 ### Added
+- `Config.to_tree()` now supports masking secure values (`secure_mask` parameter) and including
+  virtual fields in the tree (`virtual` parameter).
+
+## [v0.5.0] - 2020-10-31
+### Added
 - `StringField`: Provide available choices in the raised exception when value is not valid.
 - `Field.friendly_name()` to retrieve the friendly name of the field, either the `Field.name` or
   the full path to the field in the configuration, `Field.full_path()`

--- a/cincoconfig/abc.py
+++ b/cincoconfig/abc.py
@@ -101,7 +101,7 @@ class Field:
 
     def __init__(self, *, name: str = None, key: str = None, required: bool = False,
                  default: Union[Callable, Any] = None,
-                 validator: Callable[['BaseConfig', Any], Any] = None):
+                 validator: Callable[['BaseConfig', Any], Any] = None, sensitive: bool = False):
         '''
         All builtin Fields accept the following keyword parameters.
 
@@ -113,12 +113,14 @@ class Field:
         :param default: the default value, which can be a called that is invoke with no arguments
             and should return the default value
         :param validator: an additional validator function that is invoked during validation
+        :param sensitive: the field stores a senstive value
         '''
         self._name = name or None
         self.key = key or ''
         self.required = required
         self._default = default
         self.validator = validator
+        self.sensitive = sensitive
 
     @property
     def default(self) -> Any:

--- a/cincoconfig/config.py
+++ b/cincoconfig/config.py
@@ -667,7 +667,9 @@ class Config(BaseConfig):
                 value = self._data[key].to_tree(virtual=virtual, secure_mask=secure_mask)
             elif isinstance(field, SecureField) and secure_mask is not None:
                 value = self._data[key]
-                if len(secure_mask) == 1:
+                if not value:
+                    pass
+                elif len(secure_mask) == 1:
                     value = secure_mask * len(value)
                 else:
                     value = secure_mask

--- a/cincoconfig/config.py
+++ b/cincoconfig/config.py
@@ -10,7 +10,7 @@ from typing import Union, Any, Iterator, Tuple, Callable, List
 from argparse import Namespace
 from itertools import chain
 from .abc import Field, BaseConfig, BaseSchema, SchemaField, AnyField, ValidationError
-from .fields import IncludeField, InstanceMethodField, SecureField, VirtualField
+from .fields import IncludeField, InstanceMethodField, VirtualField
 from .formats import FormatRegistry, TFormatFactory
 
 
@@ -643,8 +643,7 @@ class Config(BaseConfig):
         The *sensitive_mask* parameter is an optional string that will repalce sensitive values in
         the tree.
 
-        - ``None`` (default) - call the field's :meth:`~cincoconfig.fields.SecureField.to_basic`
-          method.
+        - ``None`` (default) - include the value as-is in the tree
         - ``len(sensitive_mask) == 1`` (single character) - replace every character with the
           ``sensitive_mask`` character. ``value = sensitive_mask * len(value)``
         - ``len(sensitive_mask) != 1`` (empty or multicharacter string) - replace the entire value

--- a/cincoconfig/fields.py
+++ b/cincoconfig/fields.py
@@ -17,8 +17,7 @@ import base64
 import binascii
 from ipaddress import IPv4Address, IPv4Network
 from urllib.parse import urlparse
-from typing import (Union, List, Any, Iterator, Callable, NamedTuple, Optional, Dict, Iterable,
-                    TypeVar)
+from typing import Union, List, Any, Callable, NamedTuple, Optional, Dict, Iterable, TypeVar
 import hashlib
 
 from .abc import Field, AnyField, BaseConfig, BaseSchema, ConfigFormat, SchemaField
@@ -992,12 +991,12 @@ class SecureField(Field):
     '''
     storage_type = str
 
-    def __init__(self, method: str = 'best', **kwargs):
+    def __init__(self, method: str = 'best', sensitive: bool = True, **kwargs):
         '''
         :param method: encryption method, see
             :meth:`~cincoconfig.KeyFile._get_provider`
         '''
-        super().__init__(**kwargs)
+        super().__init__(sensitive=sensitive, **kwargs)
         self.method = method
 
     def to_basic(self, cfg: BaseConfig, value: str) -> Optional[dict]:

--- a/cincoconfig/fields.py
+++ b/cincoconfig/fields.py
@@ -516,7 +516,7 @@ class ListProxy(list):
 
     def __setitem__(self, index: Union[int, slice], item: Union[_T, Iterable[_T]]) -> None:
         if isinstance(index, slice) and isinstance(item, (list, tuple)):
-            super().__setitem__(index, (self._validate(i) for i in item))
+            super().__setitem__(index, [self._validate(i) for i in item])
         else:
             super().__setitem__(index, self._validate(item))
 

--- a/cincoconfig/fields.py
+++ b/cincoconfig/fields.py
@@ -75,7 +75,7 @@ class StringField(Field):
         :param value: value to validate
         '''
         if not isinstance(value, str):
-            value = str(value) if value is not None else ''
+            raise ValueError('value must be a string, not a %s' % type(value).__name__)
 
         if self.transform_strip:
             if isinstance(self.transform_strip, str):
@@ -206,6 +206,10 @@ class NumberField(Field):
         :param cfg: current Config
         :param value: value to validate
         '''
+        if not isinstance(value, (str, int, float, self.type_cls)) or isinstance(value, bool):
+            raise ValueError('value type %s cannot be converted to %s' %
+                             (type(value).__name__, self.type_cls.__name__))
+
         try:
             num = self.type_cls(value)  # type: Union[int, float]
         except (ValueError, TypeError) as err:
@@ -265,6 +269,8 @@ class IPv4AddressField(StringField):
         :param cfg: current Config
         :param value: value to validate
         '''
+        value = super()._validate(cfg, value)
+
         try:
             addr = IPv4Address(value)
         except ValueError as err:
@@ -285,6 +291,8 @@ class IPv4NetworkField(StringField):
         :param cfg: current Config
         :param value: value to validate
         '''
+        value = super()._validate(cfg, value)
+
         try:
             net = IPv4Network(value)
         except ValueError as err:
@@ -317,6 +325,8 @@ class HostnameField(StringField):
         :param cfg: current config
         :param value: value to valdiate
         '''
+        value = super()._validate(cfg, value)
+
         try:
             addr = IPv4Address(value)
         except:
@@ -453,6 +463,8 @@ class UrlField(StringField):
         :param cfg: current config
         :param value: value to validate
         '''
+        value = super()._validate(cfg, value)
+
         try:
             url = urlparse(value)
             if not url.scheme:
@@ -918,7 +930,7 @@ class ChallengeField(Field):
         elif isinstance(value, DigestValue):
             val = value
         else:
-            raise TypeError('value must be a string')
+            raise ValueError('value must be a string, not a %s' % type(value).__name__)
         return val
 
     def _hash(self, plaintext: Union[str, bytes], salt: bytes = None) -> DigestValue:
@@ -1070,7 +1082,7 @@ class BytesField(Field):
         if isinstance(value, bytes):
             return value
 
-        raise ValueError('value is not bytes')
+        raise ValueError('value must be bytes, not %s' % type(value).__name__)
 
     def to_basic(self, cfg: BaseConfig, value: bytes) -> str:
         '''

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -125,6 +125,12 @@ class TestConfig:
         config = schema()
         assert config.to_tree(virtual=False) == {}
 
+    def test_to_tree_empty_mask_secure(self):
+        schema = Schema()
+        schema.v = SecureField(method='xor', default=None)
+        config = schema()
+        assert config.to_tree(secure_mask='*') == {'v': None}
+
     def test_to_tree_secure_mask_single(self):
         schema = Schema()
         schema.v = SecureField(method='xor', default='asdf')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -129,25 +129,25 @@ class TestConfig:
         schema = Schema()
         schema.v = SecureField(method='xor', default=None)
         config = schema()
-        assert config.to_tree(secure_mask='*') == {'v': None}
+        assert config.to_tree(sensitive_mask='*') == {'v': None}
 
-    def test_to_tree_secure_mask_single(self):
+    def test_to_tree_sensitive_mask_single(self):
         schema = Schema()
         schema.v = SecureField(method='xor', default='asdf')
         config = schema()
-        assert config.to_tree(secure_mask='*') == {'v': '****'}
+        assert config.to_tree(sensitive_mask='*') == {'v': '****'}
 
-    def test_to_tree_secure_mask_multi(self):
+    def test_to_tree_sensitive_mask_multi(self):
         schema = Schema()
         schema.v = SecureField(method='xor', default='asdf')
         config = schema()
-        assert config.to_tree(secure_mask='<secret>') == {'v': '<secret>'}
+        assert config.to_tree(sensitive_mask='<secret>') == {'v': '<secret>'}
 
-    def test_to_tree_secure_mask_empty(self):
+    def test_to_tree_sensitive_mask_empty(self):
         schema = Schema()
         schema.v = SecureField(method='xor', default='asdf')
         config = schema()
-        assert config.to_tree(secure_mask='') == {'v': ''}
+        assert config.to_tree(sensitive_mask='') == {'v': ''}
 
     @patch('cincoconfig.formats.registry.FormatRegistry.get')
     def test_dumps_to_tree_args(self, fr_get):
@@ -158,12 +158,12 @@ class TestConfig:
         config = schema()
 
         virtual = object()
-        secure_mask = object()
+        sensitive_mask = object()
 
         mock_to_tree = MagicMock(returnvalue={})
         object.__setattr__(config, 'to_tree', mock_to_tree)
-        config.dumps(format='blah', virtual=virtual, secure_mask=secure_mask)
-        mock_to_tree.assert_called_once_with(virtual=virtual, secure_mask=secure_mask)
+        config.dumps(format='blah', virtual=virtual, sensitive_mask=sensitive_mask)
+        mock_to_tree.assert_called_once_with(virtual=virtual, sensitive_mask=sensitive_mask)
 
     def test_iter(self):
         schema = Schema(dynamic=True)

--- a/tests/test_fields/test_challenge.py
+++ b/tests/test_fields/test_challenge.py
@@ -94,7 +94,7 @@ class TestChallengeField:
 
     def test_validate_error(self):
         field = ChallengeField('md5', name='asdf')
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             field._validate(MockConfig(), 100)
 
     @patch.object(DigestValue, 'create')

--- a/tests/test_fields/test_list.py
+++ b/tests/test_fields/test_list.py
@@ -62,6 +62,11 @@ class TestListProxy:
         wrap[1] = '5'
         assert wrap == [1, 5, 3]
 
+    def test_setitem_slice(self):
+        wrap = ListProxy(MockConfig(), IntField(), [1, 2, '3'])
+        wrap[1:3] = ['4', '5']
+        assert wrap == [1, 4, 5]
+
     def test_copy(self):
         wrap = ListProxy(MockConfig(), IntField(), [1, 2, '3'])
         wrap2 = wrap.copy()

--- a/tests/test_fields/test_list.py
+++ b/tests/test_fields/test_list.py
@@ -5,6 +5,7 @@
 # this source code package.
 #
 from typing import List
+from unittest.mock import patch, call
 import pytest
 from cincoconfig.fields import ListField, ListProxy, IntField
 from cincoconfig.config import Schema, Config
@@ -20,11 +21,7 @@ class TestListProxy:
 
     def test_create(self):
         wrap = ListProxy(MockConfig(), IntField(), [1, 2, '3'])
-        assert wrap._items == [1, 2, 3]
-
-    def test_len(self):
-        wrap = ListProxy(MockConfig(), IntField(), [1, 2, '3'])
-        assert len(wrap) == 3
+        assert wrap == [1, 2, 3]
 
     def test_eq_list(self):
         wrap = ListProxy(MockConfig(), IntField(), [1, 2, '3'])
@@ -42,99 +39,40 @@ class TestListProxy:
     def test_append(self):
         wrap = ListProxy(MockConfig(), IntField(), [1, 2, '3'])
         wrap.append('4')
-        assert wrap._items == [1, 2, 3, 4]
+        assert wrap == [1, 2, 3, 4]
 
     def test_add_list(self):
         wrap = ListProxy(MockConfig(), IntField(), [1, 2, '3'])
         wrap2 = wrap + [4, 5]
-        assert wrap2._items == [1, 2, 3, 4, 5]
+        assert wrap2 == [1, 2, 3, 4, 5]
 
     def test_add_wrapper(self):
         wrap = ListProxy(MockConfig(), IntField(), [1, 2, '3'])
         wrap2 = ListProxy(MockConfig(), IntField(), [4, '5'])
         wrap3 = wrap + wrap2
-        assert wrap3._items == [1, 2, 3, 4, 5]
+        assert wrap3 == [1, 2, 3, 4, 5]
 
     def test_iadd(self):
         wrap = ListProxy(MockConfig(), IntField(), [1, 2, '3'])
         wrap += [4, 5]
-        assert wrap._items == [1, 2, 3, 4, 5]
-
-    def test_getitem(self):
-        wrap = ListProxy(MockConfig(), IntField(), [1, 2, '3'])
-        assert wrap[1] == 2
-
-    def test_getitem_error(self):
-        wrap = ListProxy(MockConfig(), IntField(), [1, 2, '3'])
-        with pytest.raises(IndexError):
-            _ = wrap[4]
+        assert wrap == [1, 2, 3, 4, 5]
 
     def test_setitem(self):
         wrap = ListProxy(MockConfig(), IntField(), [1, 2, '3'])
         wrap[1] = '5'
-        assert wrap._items == [1, 5, 3]
-
-    def test_clear(self):
-        wrap = ListProxy(MockConfig(), IntField(), [1, 2, '3'])
-        wrap.clear()
-        assert wrap._items == []
+        assert wrap == [1, 5, 3]
 
     def test_copy(self):
         wrap = ListProxy(MockConfig(), IntField(), [1, 2, '3'])
         wrap2 = wrap.copy()
-        assert wrap._items == wrap2._items
+        assert wrap == wrap2
         assert wrap.field is wrap2.field
         assert wrap.cfg is wrap2.cfg
-
-    def test_count(self):
-        wrap = ListProxy(MockConfig(), IntField(), [1, 2, '3'])
-        assert wrap.count(2) == 1
-
-    def test_index(self):
-        wrap = ListProxy(MockConfig(), IntField(), [1, 2, '3'])
-        assert wrap.index(3) == 2
 
     def test_insert(self):
         wrap = ListProxy(MockConfig(), IntField(), [1, 2, '3'])
         wrap.insert(1, '6')
-        assert wrap._items == [1, 6, 2, 3]
-
-    def test_pop_none(self):
-        wrap = ListProxy(MockConfig(), IntField(), [1, 2, '3'])
-        val = wrap.pop()
-        assert val == 3
-        assert wrap._items == [1, 2]
-
-    def test_pop_index(self):
-        wrap = ListProxy(MockConfig(), IntField(), [1, 2, '3'])
-        val = wrap.pop(1)
-        assert val == 2
-        assert wrap._items == [1, 3]
-
-    def test_remove(self):
-        wrap = ListProxy(MockConfig(), IntField(), [1, 2, '3'])
-        wrap.remove(2)
-        assert wrap._items == [1, 3]
-
-    def test_reverse(self):
-        wrap = ListProxy(MockConfig(), IntField(), [1, 2, '3'])
-        wrap.reverse()
-        assert wrap._items == [3, 2, 1]
-
-    def test_sort(self):
-        wrap = ListProxy(MockConfig(), IntField(), [1, 2, '3'])
-        wrap.sort(reverse=True)
-        assert wrap._items == [3, 2, 1]
-
-    def test_iter(self):
-        wrap = ListProxy(MockConfig(), IntField(), [1, 2, '3'])
-        content = list(iter(wrap))
-        assert content == [1, 2, 3]
-
-    def test_delitem(self):
-        wrap = ListProxy(MockConfig(), IntField(), [1, 2, '3'])
-        del wrap[1]
-        assert wrap._items == [1, 3]
+        assert wrap == [1, 6, 2, 3]
 
     def test_to_basic_schema(self):
         schema = Schema()
@@ -182,6 +120,25 @@ class TestListProxy:
         with pytest.raises(ValueError):
             proxy._validate(100)
 
+    def test_extend_list(self):
+        wrap = ListProxy(MockConfig(), IntField(), [1, 2, '3'])
+        with patch.object(wrap, '_validate') as mock_validate:
+            mock_validate.side_effect = [4, 5]
+            wrap.extend([4, '5'])
+            mock_validate.mock_calls = [call(4), call('5')]
+
+        assert wrap == [1, 2, 3, 4, 5]
+
+    def test_extend_proxy(self):
+        cfg = MockConfig()
+        field = IntField()
+        wrap = ListProxy(cfg, field, [1, 2, '3'])
+        with patch.object(wrap, '_validate') as mock_validate:
+            wrap.extend(ListProxy(cfg, field, [4, 5]))
+            mock_validate.assert_not_called()
+
+        assert wrap == [1, 2, 3, 4, 5]
+
 
 class TestListField:
 
@@ -201,7 +158,7 @@ class TestListField:
     def test_required_not_empty(self):
         field = ListField(IntField(), required=True)
         value = field._validate(MockConfig(), [1, 2, '3'])
-        assert value._items == [1, 2, 3]
+        assert value == [1, 2, 3]
         assert value.field is field.field
 
     def test_required_empty(self):
@@ -229,7 +186,7 @@ class TestListField:
         field = ListField(IntField(), required=True)
         wrap = field.to_python(MockConfig(), [1, 2, '3'])
         assert wrap.field is field.field
-        assert wrap._items == [1, 2, 3]
+        assert wrap == [1, 2, 3]
 
     def test_to_basic_any(self):
         field = ListField()
@@ -248,9 +205,8 @@ class TestListField:
         orig = ListProxy(MockConfig(), IntField(), [1, 2, 3])
         check = field._validate(MockConfig(), ListProxy(MockConfig(), IntField(), orig))
         assert isinstance(check, ListProxy)
-        assert check._items == orig
+        assert check == orig
         assert check is not orig
-        assert check._items is not orig._items
 
     def test_default_list_wrap(self):
         cfg = MockConfig()
@@ -258,3 +214,11 @@ class TestListField:
         field.__setdefault__(cfg)
         assert isinstance(cfg._data['asdf'], ListProxy)
         assert cfg._data['asdf'] == ListProxy(cfg, field.field, [1, 2, 3])
+
+    def test_to_basic_none(self):
+        field = ListField(IntField(), default=None, key='asdf')
+        assert field.to_basic(MockConfig(), None) is None
+
+    def test_to_basic_empty(self):
+        field = ListField(IntField(), default=None, key='asdf')
+        assert field.to_basic(MockConfig(), []) == []

--- a/tests/test_fields/test_number.py
+++ b/tests/test_fields/test_number.py
@@ -44,6 +44,11 @@ class TestIntField:
         with pytest.raises(ValueError):
             field.validate(MockConfig(), '11')
 
+    def test_non_int_convertable(self):
+        field = IntField()
+        with pytest.raises(ValueError):
+            field.validate(MockConfig(), [])
+
 
 class TestFloatField:
 

--- a/tests/test_fields/test_string.py
+++ b/tests/test_fields/test_string.py
@@ -119,7 +119,8 @@ class TestStringField:
 
     def test_non_string(self):
         field = StringField()
-        assert field.validate(self.cfg, 100) == '100'
+        with pytest.raises(ValueError):
+            field.validate(self.cfg, 100)
 
     def test_empty_string_requied(self):
         field = StringField(required=True)


### PR DESCRIPTION
- Closes #30 - Mask secure / sensitive values in `to_tree()/dumps()`
- Closes #33 - Enforce string value type
- Closes #32 - Handle empty list fields (refactor)