### PR TITLE
Track Default Values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- New support method, `is_default_value` to check if a config field value is the initial default.
+- New support method, `reset_value` to reset a configuration value back to the default.
+
+
 ## [v0.8.0](https://github.com/ameily/cincoconfig/releases/tag/v0.8.0) - 2021-07-17
 ### Added
 - Improved full reference path detection for both field and configuration objects.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 ### Added
-- New support method, `is_default_value` to check if a config field value is the initial default.
+- New support method, `is_value_defined` to check if a config field value is defined by the user,
+  through either a loaded config file or the API.
 - New support method, `reset_value` to reset a configuration value back to the default.
+- New Config method, `Config._set_default_value`, to set a field default value. This was added so
+  that `__setdefault__` methods wouldn't need to access the `_data` dictionary directly.
 
 
 ## [v0.8.0](https://github.com/ameily/cincoconfig/releases/tag/v0.8.0) - 2021-07-17

--- a/cincoconfig/__init__.py
+++ b/cincoconfig/__init__.py
@@ -10,7 +10,7 @@ Cincoconfig Public API
 from .core import Config, Field, Schema, ValidationError, AnyField, ConfigFormat, ConfigType
 from .support import (make_type, validator, get_all_fields, generate_argparse_parser,
                       item_ref_path, cmdline_args_override, asdict, get_fields, reset_value,
-                      is_default_value)
+                      is_value_defined)
 from .fields import *
 from .encryption import KeyFile
 from .stubs import generate_stub

--- a/cincoconfig/__init__.py
+++ b/cincoconfig/__init__.py
@@ -9,7 +9,8 @@ Cincoconfig Public API
 '''
 from .core import Config, Field, Schema, ValidationError, AnyField, ConfigFormat, ConfigType
 from .support import (make_type, validator, get_all_fields, generate_argparse_parser,
-                      item_ref_path, cmdline_args_override, asdict, get_fields)
+                      item_ref_path, cmdline_args_override, asdict, get_fields, reset_value,
+                      is_default_value)
 from .fields import *
 from .encryption import KeyFile
 from .stubs import generate_stub

--- a/cincoconfig/core.py
+++ b/cincoconfig/core.py
@@ -12,7 +12,7 @@ import os
 import inspect
 from collections import OrderedDict
 from functools import partial
-from typing import Union, Any, Optional, Dict, Iterator, Tuple, List, Callable, Type
+from typing import Union, Any, Optional, Dict, Iterator, Tuple, List, Callable, Type, Set
 from argparse import ArgumentParser, Namespace
 import warnings
 
@@ -881,6 +881,7 @@ class Config:  # pylint: disable=too-many-instance-attributes
         self._fields: Dict[str, BaseField] = OrderedDict()
         self._key = schema._key
         self.__keyfile = None  # type: Optional[KeyFile]
+        self._default_value_keys: Set[str] = set()
 
         if key_filename:
             self._key_filename = key_filename
@@ -893,6 +894,7 @@ class Config:  # pylint: disable=too-many-instance-attributes
                 continue
 
             field.__setdefault__(self)
+            self._default_value_keys.add(key)
 
     @property
     def _key_filename(self) -> str:
@@ -965,6 +967,7 @@ class Config:  # pylint: disable=too-many-instance-attributes
                 raise ValidationError(self, field, err) from err
             else:
                 field.__setval__(self, value)
+                self._default_value_keys.discard(key)
                 return value
 
         if isinstance(value, Config):
@@ -981,6 +984,7 @@ class Config:  # pylint: disable=too-many-instance-attributes
                                   "Unable to coerce %s to Config" % type(value).__name__)
 
         self._data[key] = value
+        self._default_value_keys.discard(key)
         return value
 
     def __setattr__(self, name: str, value: Any) -> Any:

--- a/cincoconfig/core.py
+++ b/cincoconfig/core.py
@@ -1032,6 +1032,7 @@ class Config:  # pylint: disable=too-many-instance-attributes
         return value.__getitem__(subkey) if subkey else value
 
     def __iter__(self) -> Iterator[Tuple[str, Any]]:
+        # pylint: disable=superfluous-parens
         return ((key, self._get_value(key)) for key in self._data)
 
     def __setitem__(self, key: str, value: Any) -> Any:

--- a/cincoconfig/fields/list_field.py
+++ b/cincoconfig/fields/list_field.py
@@ -145,7 +145,7 @@ class ListField(Field):
         if isinstance(default, list) and self.field:
             default = ListProxy(cfg, self, default)
 
-        cfg._data[self._key] = default
+        cfg._set_default_value(self._key, default)
 
     def _validate(self, cfg: Config, value: list) -> Union[list, ListProxy]:
         '''

--- a/cincoconfig/fields/secure_field.py
+++ b/cincoconfig/fields/secure_field.py
@@ -203,7 +203,7 @@ class ChallengeField(Field):
             val = self.default
         else:
             raise TypeError('invalid default value: %r' % self.default)
-        cfg._data[self._key] = val
+        cfg._set_default_value(self._key, val)
 
     def _validate(self, cfg: Config, value: Any) -> DigestValue:
         '''

--- a/cincoconfig/support.py
+++ b/cincoconfig/support.py
@@ -319,20 +319,20 @@ def asdict(config: Config, virtual: bool = False) -> dict:
     return data
 
 
-def is_default_value(config: Config, key: str) -> bool:
+def is_value_defined(config: Config, key: str) -> bool:
     '''
-    Check if the given field is set to the default value. This is true when the config value has
-    not been set by a loaded configuration or via the API.
+    Check if the given field has been set by the user through either loading a configuration file
+    or using the API to set the field value.
 
     :param config: configuration object
     :param key: field key
-    :returns: the field is using the default value
+    :returns: the field is set by the user
     '''
     path, _, key = key.rpartition('.')
     if path:
         config = config[path]
 
-    return key in config._default_value_keys
+    return key not in config._default_value_keys
 
 
 def reset_value(config: Config, key: str) -> None:
@@ -351,4 +351,3 @@ def reset_value(config: Config, key: str) -> None:
         raise AttributeError(key)
 
     field.__setdefault__(config)
-    config._default_value_keys.add(key)

--- a/cincoconfig/support.py
+++ b/cincoconfig/support.py
@@ -317,3 +317,38 @@ def asdict(config: Config, virtual: bool = False) -> dict:
         data.update({key: field.__getval__(config) for key, field in fields})
 
     return data
+
+
+def is_default_value(config: Config, key: str) -> bool:
+    '''
+    Check if the given field is set to the default value. This is true when the config value has
+    not been set by a loaded configuration or via the API.
+
+    :param config: configuration object
+    :param key: field key
+    :returns: the field is using the default value
+    '''
+    path, _, key = key.rpartition('.')
+    if path:
+        config = config[path]
+
+    return key in config._default_value_keys
+
+
+def reset_value(config: Config, key: str) -> None:
+    '''
+    Reset a config value back to the default.
+
+    :param config: configuration object
+    :param key: field key
+    '''
+    path, _, key = key.rpartition('.')
+    if path:
+        config = config[path]
+
+    field = config._get_field(key)
+    if not field:
+        raise AttributeError(key)
+
+    field.__setdefault__(config)
+    config._default_value_keys.add(key)

--- a/docs/configs.rst
+++ b/docs/configs.rst
@@ -20,6 +20,7 @@ configs
 
     .. automethod:: _get_field
     .. automethod:: _set_value
+    .. automethod:: _set_default_value
     .. automethod:: _get_value
     .. automethod:: __setattr__
     .. automethod:: __getattr__

--- a/docs/support.rst
+++ b/docs/support.rst
@@ -16,3 +16,7 @@ support
 .. autofunction:: cincoconfig.get_fields
 
 .. autofunction:: cincoconfig.asdict
+
+.. autofunction:: cincoconfig.is_default_value
+
+.. autofunction:: cincoconfig.reset_value

--- a/docs/support.rst
+++ b/docs/support.rst
@@ -17,6 +17,6 @@ support
 
 .. autofunction:: cincoconfig.asdict
 
-.. autofunction:: cincoconfig.is_default_value
+.. autofunction:: cincoconfig.is_value_defined
 
 .. autofunction:: cincoconfig.reset_value

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -727,3 +727,25 @@ class TestConfig:
         config = schema()
         assert config.load_tree({}, validate=False) is None
 
+    def test_default_keys(self):
+        schema = Schema()
+        schema.a.b = Field(default=0)
+        schema.x = Field(default=1)
+        schema.y = Field(default=2)
+        schema.z = Field(default=3)
+        config = schema(y=2, z=4)
+        assert config._default_value_keys == set(['a', 'x'])
+
+    def test_default_keys_override(self):
+        schema = Schema()
+        schema.x = Field(default=1)
+        config = schema()
+        config.x = 1
+        assert config._default_value_keys == set()
+
+    def test_default_keys_config_override(self):
+        schema = Schema()
+        schema.x.y = Field(default=1)
+        config = schema()
+        config.x = {'y': 2}
+        assert config._default_value_keys == set()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -749,3 +749,10 @@ class TestConfig:
         config = schema()
         config.x = {'y': 2}
         assert config._default_value_keys == set()
+
+    def test_set_default_value(self):
+        schema = Schema()
+        config = schema()
+        config._set_default_value('x', 'asdf')
+        assert config._data == {'x': 'asdf'}
+        assert config._default_value_keys == set(['x'])

--- a/tests/test_fields/test_configtype_field.py
+++ b/tests/test_fields/test_configtype_field.py
@@ -11,7 +11,7 @@ class TestConfigTypeField:
         cfg._data = {}
         field = ConfigTypeField(mock_ct, key='x')
         field.__setdefault__(cfg)
-        assert cfg._data == {'x': retval}
+        cfg._set_default_value.assert_called_once_with('x', retval)
         mock_ct.assert_called_once_with(cfg)
 
     def test_call(self):

--- a/tests/test_fields/test_field.py
+++ b/tests/test_fields/test_field.py
@@ -18,6 +18,7 @@ class MockConfig:
         self._parent = parent
         self._key = key
         self._schema = Schema()
+        self._set_default_value = MagicMock()
 
     def _full_path(self):
         return ''
@@ -58,7 +59,7 @@ class TestBaseField:
     def test_setdefault(self):
         field = Field(key='key', default='hello')
         field.__setdefault__(self.cfg)
-        assert self.cfg._data['key'] == 'hello'
+        self.cfg._set_default_value.assert_called_once_with('key', 'hello')
 
     def test_to_python(self):
         field = Field()

--- a/tests/test_fields/test_list.py
+++ b/tests/test_fields/test_list.py
@@ -5,7 +5,7 @@
 # this source code package.
 #
 from typing import List
-from unittest.mock import patch, call
+from unittest.mock import patch, call, MagicMock
 import pytest
 from cincoconfig.fields import ListField, ListProxy, IntField
 from cincoconfig.core import Schema, Config, ValidationError
@@ -15,6 +15,7 @@ class MockConfig:
 
     def __init__(self):
         self._data = {}
+        self._set_default_value = MagicMock()
 
 
 class TestListProxy:
@@ -298,8 +299,9 @@ class TestListField:
         cfg = MockConfig()
         field = ListField(IntField(), default=lambda: [1, 2, 3], key='asdf')
         field.__setdefault__(cfg)
-        assert isinstance(cfg._data['asdf'], ListProxy)
-        assert cfg._data['asdf'] == ListProxy(cfg, field, [1, 2, 3])
+        cfg._set_default_value.assert_called_once_with('asdf', ListProxy(cfg, field, [1, 2, 3]))
+        # assert isinstance(cfg._data['asdf'], ListProxy)
+        # assert cfg._data['asdf'] == ListProxy(cfg, field, [1, 2, 3])
 
     def test_to_basic_none(self):
         field = ListField(IntField(), default=None, key='asdf')

--- a/tests/test_fields/test_net.py
+++ b/tests/test_fields/test_net.py
@@ -22,7 +22,7 @@ class TestIPv4AddressField:
 
     def test_valid_ipv4(self):
         field = IPv4AddressField()
-        assert field.validate(MockConfig(), '192.168.001.1') == '192.168.1.1'
+        assert field.validate(MockConfig(), '192.168.1.1') == '192.168.1.1'
 
     def test_invalid_ipv4(self):
         field = IPv4AddressField()
@@ -34,7 +34,7 @@ class TestIPv4NetworkField:
 
     def test_valid_net(self):
         field = IPv4NetworkField()
-        assert field.validate(MockConfig(), '192.168.001.0/24') == '192.168.1.0/24'
+        assert field.validate(MockConfig(), '192.168.1.0/24') == '192.168.1.0/24'
 
     def test_invalid_net(self):
         field = IPv4NetworkField()
@@ -64,7 +64,7 @@ class TestHostnameField:
 
     def test_valid_ipv4(self):
         field = HostnameField(allow_ipv4=True)
-        assert field.validate(MockConfig(), '192.168.001.1') == '192.168.1.1'
+        assert field.validate(MockConfig(), '192.168.1.1') == '192.168.1.1'
 
     def test_no_ipv4(self):
         field = HostnameField(allow_ipv4=False)

--- a/tests/test_support.py
+++ b/tests/test_support.py
@@ -6,7 +6,7 @@ import pytest
 
 from cincoconfig.fields import StringField, IntField, BoolField, FloatField, VirtualField
 from cincoconfig.core import Schema, Field, Config
-from cincoconfig.support import (generate_argparse_parser, get_fields, is_default_value, make_type,
+from cincoconfig.support import (generate_argparse_parser, get_fields, is_value_defined, make_type,
                                  get_all_fields, cmdline_args_override, reset_value, validator,
                                  item_ref_path, asdict, _list_asdict)
 
@@ -234,17 +234,17 @@ class TestSupportFuncs:
         assert result[0] == x
         assert result[0] is not x
 
-    def test_is_default_value(self):
+    def test_is_value_defined(self):
         config = MagicMock(_default_value_keys=set(['x']))
-        assert is_default_value(config, 'x') is True
-        assert is_default_value(config, 'y') is False
+        assert is_value_defined(config, 'x') is False
+        assert is_value_defined(config, 'y') is True
 
-    def test_is_default_value_nested(self):
+    def test_is_value_defined_nested(self):
         config = {
             'sub': MagicMock(_default_value_keys=set(['x']))
         }
-        assert is_default_value(config, 'sub.x') is True
-        assert is_default_value(config, 'sub.y') is False
+        assert is_value_defined(config, 'sub.x') is False
+        assert is_value_defined(config, 'sub.y') is True
 
     def test_reset_value(self):
         config = MagicMock()
@@ -252,7 +252,6 @@ class TestSupportFuncs:
         reset_value(config, 'x')
         config._get_field.assert_called_once_with('x')
         field.__setdefault__.assert_called_once_with(config)
-        config._default_value_keys.add.assert_called_once_with('x')
 
     def test_reset_value_nested(self):
         config = MagicMock()
@@ -260,7 +259,6 @@ class TestSupportFuncs:
         reset_value({'sub': config}, 'sub.x')
         config._get_field.assert_called_once_with('x')
         field.__setdefault__.assert_called_once_with(config)
-        config._default_value_keys.add.assert_called_once_with('x')
 
     def test_reset_value_attribute_error(self):
         config = MagicMock()


### PR DESCRIPTION
This PR adds a `is_default_value` that checks if the configuration value was set to the default. This will return true if config value was set via `__setdefault__` and not overridden by a configuration file or through the API. This method doesn't actual check the *value* of the field. So, if you explicitly set the value to the default, `is_default_value` will return `False`. Also, mutable types, such as list, dict, or a nested config, will return `True` even if a nested field has been modified.

```python
>>> from cincoconfig import Schema, is_default_value, Field
>>> schema = Schema()
>>> schema.x = Field(default=1)
>>> schema.y.z = Field(default=2)
>>> config1 = schema()
>>> is_default_value(config1, 'x')
True
>>> config1.x = 1
>>> is_default_value(config1, 'x')
False
>>> config2 = schema(x=1)
>>> is_default_value(config2, 'x')
False
>>> is_default_value(config2, 'y')
True
>>> config2.y.z = 100
>>> is_default_value(config2, 'y')
True
>>> is_default_value(config2, 'y.z')
False
```

This PR also adds a `reset_value` that can be used to reset a config value to the default.

```python
>>> from cincoconfig import reset_value
>>> config1.x = 100
>>> reset_value(config1, 'x')
>>> config1.x
1
```

Closes #51 